### PR TITLE
NO-TASK - Display Marcxchange subjects for ting_subjects field.

### DIFF
--- a/ting_subjects_override.info
+++ b/ting_subjects_override.info
@@ -3,3 +3,6 @@ description = Overrides ting object details subject field in order to display MA
 package = Ding!
 core = 7.x
 version = 7.x-5.0.0
+dependencies[] = ting
+dependencies[] = ting_search
+dependencies[] = opensearch

--- a/ting_subjects_override.module
+++ b/ting_subjects_override.module
@@ -34,3 +34,27 @@ function ting_subjects_override_entity_prepare_view($entities, $type, $langcode)
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function ting_subjects_override_preprocess_field(&$variables) {
+  $field_name = $variables["element"]["#field_name"];
+
+  if ($field_name == 'ting_subjects') {
+    $object = $variables['element']['#object'];
+
+    if (!empty($object->subjects)) {
+      $search_string = variable_get('ting_search_register_subject', 'phrase.subject="@subject"');
+      $subject_links = array_map(function ($subject) use ($search_string) {
+        $replacement = array('@subject' => $subject);
+        $options = array(
+          'attributes' => array('class' => array('subject')),
+        );
+        return ting_field_search_link($subject, $search_string, $replacement, $options);
+      }, $object->subjects);
+
+      $variables['items'][0]['#markup'] = implode(' ', $subject_links);
+    }
+  }
+}


### PR DESCRIPTION
`ting_subjects` field is not using custom subjects from Marcxchange.